### PR TITLE
fix: mostly pretty links, fix dev warnings

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -11,10 +11,10 @@ module.exports = {
 
     nav: [
       { text: "Home", link: "/", activeMatch: "^/$|^/home/" },
-      { text: "Bridge", link: "/bridge/index.html", activeMatch: "^/bridge" },
+      { text: "Bridge", link: "/bridge/", activeMatch: "^/bridge" },
       {
         text: "Developer Resources",
-        link: "/dev/index.html",
+        link: "/dev/",
         activeMatch: "^/dev/",
       },
     ],
@@ -31,31 +31,31 @@ module.exports = {
 function getHomeSidebar() {
   return [
     { text: "What is Nomad?", link: "/" },
-    { text: "Brand Kit", link: "/brand-kit.html" },
+    { text: "Brand Kit", link: "/brand-kit" },
   ];
 }
 
 function getBridgeSidebar() {
   return [
-    { text: "Getting Started", link: "/bridge/index.html" },
+    { text: "Getting Started", link: "/bridge/" },
     {
       text: "Resources",
       children: [
-        { text: "Deployed Tokens", link: "/bridge/deployed-tokens.html" },
+        { text: "Deployed Tokens", link: "/bridge/deployed-tokens" },
       ],
     },
-    { text: "FAQs", link: "/bridge/faq.html" },
+    { text: "FAQs", link: "/bridge/" },
     {
       text: "Ways to Bridge Using Nomad",
       children: [
-        { text: "Nomad GUI", link: "/bridge/nomad-gui.html" },
+        { text: "Nomad GUI", link: "/bridge/" },
         {
           text: "Send Native Tokens Using Etherscan",
-          link: "/bridge/etherscan-native.html",
+          link: "/bridge/etherscan-native",
         },
         {
           text: "Send ERC-20 Tokens Using Etherscan",
-          link: "/bridge/etherscan.html",
+          link: "/bridge/etherscan",
         },
       ],
     },
@@ -67,17 +67,17 @@ function getIntegrationsSidebar() {
     {
       text: "Technical Docs",
       children: [
-        { text: "Nomad Architecture", link: "/dev/architecture.html" },
-        { text: "Token Bridge xApp", link: "/dev/token-bridge.html" },
-        { text: "Governance", link: "/dev/governance.html" },
-        { text: "Upgrade Setup", link: "/dev/upgrade-setup.html" },
+        { text: "Nomad Architecture", link: "/dev/architecture" },
+        { text: "Token Bridge xApp", link: "/dev/token-bridge" },
+        { text: "Governance", link: "/dev/governance" },
+        { text: "Upgrade Setup", link: "/dev/upgrade-setup" },
         {
           text: "Deploy Contracts to Dev",
-          link: "/dev/dev-contract-deployment.html",
+          link: "/dev/dev-contract-deployment",
         },
         {
           text: "Deploy Contracts to Prod",
-          link: "/dev/prod-contract-deployment.html",
+          link: "/dev/prod-contract-deployment",
         },
         { text: "Off-Chain Agents", link: "/dev/agents/" },
       ],
@@ -85,8 +85,8 @@ function getIntegrationsSidebar() {
     {
       text: "Developer Resources",
       children: [
-        { text: "SDK", link: "/dev/sdk.html" },
-        { text: "Writing a xApp", link: "/dev/xapps.html" },
+        { text: "SDK", link: "/dev/sdk" },
+        { text: "Writing a xApp", link: "/dev/xapps" },
       ],
     },
   ];

--- a/docs/bridge/nomad-gui.md
+++ b/docs/bridge/nomad-gui.md
@@ -13,8 +13,8 @@ Nomad is a secure gas efficient cross-chain protocol that allows users to bridge
 
 Connext is not available for every asset and may not be available for larger sums. If it is available, we provide this option by default. If you would like to use Nomad instead, you can temporarily switch by clicking "Use Nomad" or you can toggle off "Enable Connext" in settings.
 
-![Switch to Nomad](../public/tutorials/bridge-gui/use-nomad.png)
-![Enables/Disable Connext](../public/tutorials/bridge-gui/enable-connext.png)
+![Switch to Nomad](../tutorials/bridge-gui/use-nomad.png)
+![Enables/Disable Connext](../tutorials/bridge-gui/enable-connext.png)
 
 ## Bridging Through Nomad
 
@@ -28,32 +28,32 @@ If you would like to test our bridge using testnet funds before using real funds
 
 Connect to Metamask:
 
-![Connect to Metamask](../public/tutorials/bridge-gui/connect-metamask.png)
+![Connect to Metamask](../tutorials/bridge-gui/connect-metamask.png)
 
 <br>
 
 Select origin and destination networks:
 
-![Select Origin and Destination Networks](../public/tutorials/bridge-gui/choose-networks.png)
+![Select Origin and Destination Networks](../tutorials/bridge-gui/choose-networks.png)
 
 <br>
 
 (Optional) Change Destination address. This is set as your wallet address be default. ::: CAUTION Sending assets to an address you do not control can result in a permanent loss of funds! ::: Click "edit", click "change" inside input, then copy your address, click to paste, then Save.
 
-![Change Destination](../public/tutorials/bridge-gui/change-dest-1.png)
-![Paste Destination](../public/tutorials/bridge-gui/change-dest-2.png)
+![Change Destination](../tutorials/bridge-gui/change-dest-1.png)
+![Paste Destination](../tutorials/bridge-gui/change-dest-2.png)
 
 <br>
 
 Select the asset you want to send using the asset dropdown menu and the amount you want to send using the input prompt:
 
-![Select an Asset and Amount](../public/tutorials/bridge-gui/select-asset-amount.png)
+![Select an Asset and Amount](../tutorials/bridge-gui/select-asset-amount.png)
 
 <br>
 
 Click `Bridge Tokens` and approve the transaction in Metamask:
 
-![Approve Bridge Transaction](../public/tutorials/bridge-gui/approve-send-tx.png)
+![Approve Bridge Transaction](../tutorials/bridge-gui/approve-send-tx.png)
 
 <br>
 
@@ -63,25 +63,25 @@ After approving the transaction, you will be taken to the transaction details pa
 You must return to the Transaction Page after bridging has concluded to pay for gas and complete your transfer. Nomad may cover the processing and gas fees for some chains.
 :::
 
-![See Transaction Details](../public/tutorials/bridge-gui/tx-hash-page.png)
+![See Transaction Details](../tutorials/bridge-gui/tx-hash-page.png)
 
 <br>
 
 You can expand the time estimate tab to track your transaction status by clicking the down arrow in the blue box:
 
-![See Expanded Transaction Details](../public/tutorials/bridge-gui/tx-hash-page-expanded.png)
+![See Expanded Transaction Details](../tutorials/bridge-gui/tx-hash-page-expanded.png)
 
 <br>
 
 (Optional) If you navigated away from the GUI at any point and want to find your transfer's progress page again, visit [https://app.nomad.xyz/tx](https://app.nomad.xyz/tx) and enter the origin network and your transfer's transaction hash.
 
-![Search Tx](../public/tutorials/bridge-gui/search-tx.png)
+![Search Tx](../tutorials/bridge-gui/search-tx.png)
 
 <br>
 
 Once your transfer has completed, you should see the below display and your funds will be in the account of your destination address. If your transfer is taking longer than expected, please reach out to us on [Discord](https://discord.gg/RurtmJApqm) in the #support channel:
 
-![Finished](../public/tutorials/bridge-gui/tx-finished.png)
+![Finished](../tutorials/bridge-gui/tx-finished.png)
 
 <br>
 
@@ -89,7 +89,7 @@ Once your transfer has completed, you should see the below display and your fund
 
 If you are sending to Ethereum, there is one additional processing step due to the high cost of processing transactions on Ethereum. You will see the following display and should click "Complete Transfer" and complete the Metamask transaction. After this, your funds should be at your destination on Ethereum!
 
-![Self Process](../public/tutorials/bridge-gui/self-process.png)
+![Self Process](../tutorials/bridge-gui/self-process.png)
 
 <br>
 
@@ -99,15 +99,15 @@ Fill out transfer details: connect wallet, select token, enter amount, select or
 
 Once the input is filled out and valid, the app will check if there is available liquidity via Connext.
 
-![Checking availability](../public/tutorials/bridge-gui/checking-connext.png)
+![Checking availability](../tutorials/bridge-gui/checking-connext.png)
 
 If there is, your screen will look like this. You may proceed with Connext or click "Use Nomad" to switch.
 
-![Connext available](../public/tutorials/bridge-gui/connext-available.png)
+![Connext available](../tutorials/bridge-gui/connext-available.png)
 
 Click "Preview Send" to see the estimated fees and receive amount. It will take approximately 6-8 seconds for the results to appear.
 
-![Calculating fee](../public/tutorials/bridge-gui/calculating-fees.png)
+![Calculating fee](../tutorials/bridge-gui/calculating-fees.png)
 
 Click `Send Tokens` and approve the transaction in Metamask!
 
@@ -115,4 +115,4 @@ In a few minutes, you will see your transfer appear in a table below. Click "Cla
 
 Click "View" to go to your transaction in the ConnextScan block explorer. Or you can visit `https://connextscan.io/tx/<yourtransactionhash>`.
 
-![Claim Connext funds](../public/tutorials/bridge-gui/connext-claim.png)
+![Claim Connext funds](../tutorials/bridge-gui/connext-claim.png)

--- a/docs/dev/agents/debug-agents.md
+++ b/docs/dev/agents/debug-agents.md
@@ -23,25 +23,25 @@ The most important birds-eye-view dashboard for initially spotting a regression 
 
 First navigate to the Bridge Health dashboard as shown below. On the main page, click on the `Search dashboards` tab on the far left.
 
-![Find Explore](../public/../../public/tutorials/debug-agents/find-dashboards.png)
+![Find Explore](../../tutorials/debug-agents/find-dashboards.png)
 
 <br>
 
 Now find the Bridge Health dashboard among the listed dashboards.
 
-![Find Bridge Health](../public/../../public/tutorials/debug-agents/find-bridge-health.png)
+![Find Bridge Health](../../tutorials/debug-agents/find-bridge-health.png)
 
 <br>
 
 Now that we have the `Bridge Health` dashboard in front of us, we spot a regression. In the highlighted region, we see that while the number of unprocessed messages continued increasing, the number of processed messages did not, meaning that there was a some kind of stall. This is almost always what regressions look like.
 
-![Regression Found](../public/../../public/tutorials/debug-agents/identify-regression.png)
+![Regression Found](../../tutorials/debug-agents/identify-regression.png)
 
 <br>
 
 Highlight the regression to zoom in. We can already see a plethora of errors emitted during the stall in the error graph below the regression. More importantly, by highlighting the regression, we have identified the start and end timestamps for which the regression occurred (see top right corner).
 
-![Regression Zoom](../public/../../public/tutorials/debug-agents/zoom-in-regression.png)
+![Regression Zoom](../../tutorials/debug-agents/zoom-in-regression.png)
 
 <br>
 
@@ -51,37 +51,37 @@ Now that we know the general timestamp of the regression, we know where to look 
 
 Once you have navigated to the `Agents` dashboard, copy-paste the regression timestamps into the timestamp window in the top right. This will narrow our examination window.
 
-![Agents Timestamp Paste](../public/../../public/tutorials/debug-agents/agents-timestamp-paste.png)
+![Agents Timestamp Paste](../../tutorials/debug-agents/agents-timestamp-paste.png)
 
 <br>
 
 Once we've narrowed our time window, let's look at the processor `next_message_nonce` metric. This metric tracks what message a given processor is currently on for each channel. The `next_message_nonce` should be moving up and to the right if all is healthy. In the highlighted region, however, it looks it looks like the Moonbase processor metric stopped being reported.
 
-![Zoom Agent Regression](../public/../../public/tutorials/debug-agents/agents-no-zoom.png)
+![Zoom Agent Regression](../../tutorials/debug-agents/agents-no-zoom.png)
 
 <br>
 
 Lets zoom in even more to see the discontinued reporting.
 
-![Zoom Agent Regression](../public/../../public/tutorials/debug-agents/agents-regression-zoom.png)
+![Zoom Agent Regression](../../tutorials/debug-agents/agents-regression-zoom.png)
 
 <br>
 
 Now that we have a better idea of what our issue might be, let's check if our hypothesis about crash looping is correct using Grafana logs. Navigate back to the Grafana home page and find the `Explore` tab on the far left.
 
-![Find Explore](../public/../../public/tutorials/debug-agents/find-explore.png)
+![Find Explore](../../tutorials/debug-agents/find-explore.png)
 
 <br>
 
 You should see a prompt at the top where you can write log queries. To query Grafana logs, we write Loki queries. For more details on writing Loki queries to narrow down your searches, see this [cheat sheet](https://grafana.com/docs/loki/latest/logql/log_queries/). Here, we just want a simple query that shows all logs during the time window for the Moonbase processor (see query in prompt).
 
-![Write Query](../public/../../public/tutorials/debug-agents/enter-agent-pod-and-timestamp.png)
+![Write Query](../../tutorials/debug-agents/enter-agent-pod-and-timestamp.png)
 
 <br>
 
 If we look at our query results, we can see, the Moonbase processor is indeed crash looping with some error about a local root mismatch. This is when we would go back to the codebase and piece together the root cause of the error. The same applies for stalls that are not emitting explicit errors.
 
-![Error Logs](../public/../../public/tutorials/debug-agents/log-errors.png)
+![Error Logs](../../tutorials/debug-agents/log-errors.png)
 
 <br>
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -7,7 +7,7 @@ lang: en-US
 
 ## Components
 
-![Nomad Architecture Diagram](../public/Nomad-Architecture.png)
+![Nomad Architecture Diagram](../Nomad-Architecture.png)
 
 Nomad has several logical components:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,7 @@ Instead, Nomad guarantees the following:
 
 Nomad contains several on-chain and off-chain components. For convenience, we’ll be referring to the Home and Replica as contracts, when in fact they are several contracts working together.
 
-![Nomad Components](./public/Nomad-Architecture.png)
+![Nomad Components](./Nomad-Architecture.png)
 
 ## On-chain (Contracts)
 

--- a/docs/tutorials/governance-onboarding.md
+++ b/docs/tutorials/governance-onboarding.md
@@ -48,33 +48,33 @@ NOTE: The direct ledger integration on MyCrypto.com's Message Signature tool is 
 
 Select a wallet: 
 
-![Wallet Selection Modal](../public/tutorials/governance-signer/select-wallet.png)
+![Wallet Selection Modal](../tutorials/governance-signer/select-wallet.png)
 
 Connect to Metamask: 
 
-![Connect to Metamask](../public/tutorials/governance-signer/connect-to-metamask.png)
+![Connect to Metamask](../tutorials/governance-signer/connect-to-metamask.png)
 
 Confirm Address: 
 
-![Connect to Metamask](../public/tutorials/governance-signer/confirm-address.png)
+![Connect to Metamask](../tutorials/governance-signer/confirm-address.png)
 
 2. Sign Message 
 
 Now that your wallet is connected, we can use the MyCrypto UI to sign your choice of message from the above options. 
 
-![Sign a Message](../public/tutorials/governance-signer/sign-message.png)
+![Sign a Message](../tutorials/governance-signer/sign-message.png)
 
 Approve the signature in Metamask: 
 
-![Approve Signature in Metamask](../public/tutorials/governance-signer/approve-on-metamask.png)
+![Approve Signature in Metamask](../tutorials/governance-signer/approve-on-metamask.png)
 
 Approve the Signature on your Device: 
 
-![Approve Signature on Wallet](../public/tutorials/governance-signer/approve-on-device.png)
+![Approve Signature on Wallet](../tutorials/governance-signer/approve-on-device.png)
 
 Nice! You should now have a successful signature output in the MyCrypto UI: 
 
-![Signature Success](../public/tutorials/governance-signer/signature-success.png)
+![Signature Success](../tutorials/governance-signer/signature-success.png)
 
 Here's what the output of your signature should look like: 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "docs",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "Apache 2.0",
       "dependencies": {
         "vitepress": "^0.20.1"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
-    "docs:serve": "vitepress serve --port 8000 docs"
+    "docs:serve": "vitepress serve --port 8000 docs",
+    "postinstall": "node -e \"var fs=require('fs'),js='node_modules/vitepress/dist/client/app/router.js';fs.writeFileSync(js,fs.readFileSync(js,'utf8').replace(\\\"url.pathname += '.html';\\\",''))\""
   },
   "author": "Erin Hales",
   "license": "Apache 2.0",


### PR DESCRIPTION
Fixes some of #23 

Most links should not have the `.html` ending now. The ones that still exist are routes that are linked in `md` files.

There is no way to get around this in vitepress. The only workaround I found was editing the vitepress dependency directly post install (see package.json and [this issue from vitepress](https://github.com/vuejs/vitepress/issues/219#issuecomment-944883721))

Perfectly fine if we choose not to merge this change since I don't think the `.html` endings is a big deal (vitepress main site has the same "problem" - https://vitepress.vuejs.org/config/basics.html)